### PR TITLE
feat: add GitHub token for github last edit

### DIFF
--- a/app/docs/[[...slug]]/page.tsx
+++ b/app/docs/[[...slug]]/page.tsx
@@ -22,6 +22,7 @@ export default async function Page(props: {
     owner: "whyte25",
     repo: "reusables",
     path: `content/docs/${page.file.path}`,
+    token: process.env.GITHUB_TOKEN,
   });
 
   return (


### PR DESCRIPTION
An error occurred Vercel because of GitHub's API rate limiting. To increase your API request limit, add GitHub token