### PR TITLE
Dev

### DIFF
--- a/app/docs/[[...slug]]/page.tsx
+++ b/app/docs/[[...slug]]/page.tsx
@@ -22,7 +22,7 @@ export default async function Page(props: {
     owner: "whyte25",
     repo: "reusables",
     path: `content/docs/${page.file.path}`,
-    token: process.env.GITHUB_TOKEN,
+    token: `Bearer ${process.env.GITHUB_TOKEN}`,
   });
 
   return (

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,14 @@
+import { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: ["/", "/docs/*", "/sitemap.xml"],
+        disallow: ["/api/*", "/preview/*"],
+      },
+    ],
+    sitemap: `${process.env.NEXT_PUBLIC_SITE_URL}/sitemap.xml`,
+  };
+}

--- a/app/robots.txt
+++ b/app/robots.txt
@@ -1,4 +1,0 @@
-User-Agent: *
-Allow: /
-
-Sitemap: https://reusables.vercel.app/sitemap.xml

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,6 @@
+import sitemap from "@/lib/sitemap";
+import { MetadataRoute } from "next";
+
+export default async function SitemapRoute(): Promise<MetadataRoute.Sitemap> {
+  return sitemap();
+}

--- a/lib/sitemap.ts
+++ b/lib/sitemap.ts
@@ -1,0 +1,28 @@
+import { MetadataRoute } from "next";
+
+const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000";
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const routes = [
+    {
+      url: `${baseUrl}`,
+      lastModified: new Date(),
+      changeFrequency: "daily",
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/docs`,
+      lastModified: new Date(),
+      changeFrequency: "daily",
+      priority: 0.8,
+    },
+    {
+      url: `${baseUrl}/preview`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.6,
+    },
+  ] as const;
+
+  return [...routes];
+}


### PR DESCRIPTION

- Update robots rules to explicitly define allowed paths:
  - Homepage (/)
  - Documentation pages (/docs/*)
  - Sitemap (/sitemap.xml)
- Add wildcards (*) to path patterns for better clarity
- Keep sitemap reference for search engine discovery
