### PR TITLE
chore: version notify package

### DIFF
--- a/.changeset/odd-radios-win.md
+++ b/.changeset/odd-radios-win.md
@@ -1,5 +1,0 @@
----
-"reusables-notify": patch
----
-
-Update the npm README with documentation, GitHub, usage, and shadcn registry links.

--- a/packages/notify/CHANGELOG.md
+++ b/packages/notify/CHANGELOG.md
@@ -1,5 +1,11 @@
 # reusables-notify
 
+## 0.1.2
+
+### Patch Changes
+
+- d7a443b: Update the npm README with documentation, GitHub, usage, and shadcn registry links.
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/notify/package.json
+++ b/packages/notify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reusables-notify",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A composable toast notification package for React.",
   "license": "MIT",
   "homepage": "https://reusables.vercel.app/docs/components/notify",


### PR DESCRIPTION
## Summary

- Version `reusables-notify` to `0.1.2` for the npm README/package metadata update.
- Move the changeset note into `packages/notify/CHANGELOG.md`.

## Validation

- `bunx prettier --check packages/notify/package.json packages/notify/CHANGELOG.md`
- `bun run --cwd packages/notify typecheck`
- `bun run --cwd packages/notify build`
- `npm pack --dry-run` from `packages/notify`

## Note

The automated version PR failed because repository Actions currently cannot create PRs. Enable **Settings → Actions → General → Workflow permissions → Allow GitHub Actions to create and approve pull requests** so Changesets can create this PR automatically next time.